### PR TITLE
Add settimeout on createElevation sparkline to avoid canvas doesn't load

### DIFF
--- a/src/app/map/services.js
+++ b/src/app/map/services.js
@@ -830,7 +830,9 @@ function mapService($rootScope, $q, $state, $resource, $translate, $filter, util
                 }
 
                 function updateSparkline() {
-                    jQuery('#elevation .detail-content-elevation-canvas').sparkline(data.profile, sparklineOptions);
+                    setTimeout(function() {
+                        jQuery('#elevation .detail-content-elevation-canvas').sparkline(data.profile, sparklineOptions);
+                    }, 200);
                 }
 
                 updateSparkline();


### PR DESCRIPTION
Quand on ouvre le détail d'un trek, le graph du dénivelé s'affiche bien, si on retourne sur la liste et qu'on revient sur le même trek, le dénivelé ne s'affiche plus.
Un setTimeout sur la génération du canvas permet de détourner le problème.