### PR TITLE
WIP: Add Leaflet snogylop to Geotrek so polygons can be reversed, #608

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4346,6 +4346,10 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-0.4.0.tgz"
     },
+    "leaflet.snogylop": {
+      "version": "0.4.0",
+      "resolved": "git+https://github.com/ebrelsford/Leaflet.snogylop.git#f0e5846e5b8e2614b20beff84c0c7e9531294a9a"
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "leaflet-pip": "^1.1.0",
     "leaflet-textpath": "git+https://github.com/makinacorpus/Leaflet.TextPath.git#c45041b4687c8c46b9bb39b8f93623c933108d19",
     "leaflet.markercluster": "^0.4.0",
+    "leaflet.snogylop": "git+https://github.com/ebrelsford/Leaflet.snogylop.git#f0e5846e5b8e2614b20beff84c0c7e9531294a9a",
     "lodash": "^4.17.4",
     "merge-stream": "^1.0.1",
     "mkdirp": "^0.5.1",

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -82,6 +82,7 @@ require('leaflet.markercluster');
 require('leaflet-fullscreen');
 
 require('../../node_modules/leaflet-active-area/src/leaflet.activearea.js');
+require('leaflet.snogylop');
 
 //TEST LIBRARIES
 require('angular-mocks'); // that one will exclude if not angular.mock


### PR DESCRIPTION
This change is not complete as style properties don't seem to be applied correctly.
For instance, the `fill-opacity` property as no effect.

This needs more work.