### PR TITLE
Change leaflet-minimap package link to fix map infinite move near bounds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 2.26.1-dev0
 ===========
 
-**Enhancements**
+**Bug fixes**
+
+* Fix map infinite move (was due to a bug on leaflet-minimap)
 
 2.26.0 / 2020-07-16
 ===================

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 **Bug fixes**
 
 * Fix map infinite move (was due to a bug on leaflet-minimap)  
-  Run `npm update leaflet-minimap` to update it
+  Run `npm update leaflet-minimap` to update it. Leaflet-minimap
+  package is temporarly pinned to a fork, waiting this PR to be merged
+  https://github.com/Norkart/Leaflet-MiniMap/pull/155
 
 2.26.0 / 2020-07-16
 ===================

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@
 
 **Bug fixes**
 
-* Fix map infinite move (was due to a bug on leaflet-minimap)
+* Fix map infinite move (was due to a bug on leaflet-minimap)  
+  Run `npm update leaflet-minimap` to update it
 
 2.26.0 / 2020-07-16
 ===================

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "leaflet-ajax": "^2.1.0",
     "leaflet-fullscreen": "^1.0.2",
     "leaflet-geometryutil": "^0.9.2",
-    "leaflet-minimap": "^3.6.1",
+    "leaflet-minimap": "git+https://github.com/bastyen/Leaflet-MiniMap.git#fe3ba7d1ffcc9b6ad6924c760629a9af4e412b4d",
     "leaflet-pip": "^1.1.0",
     "leaflet-textpath": "^1.2.3",
     "leaflet.markercluster": "^1.4.1",


### PR DESCRIPTION
Run `npm up leaflet-minimap` to install new version of package.
This version is temporarly a patch in a fork, waiting for the official version to be released (PR https://github.com/Norkart/Leaflet-MiniMap/pull/155)